### PR TITLE
Add pytest check for index page

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,14 @@
+name: Python Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: python -m pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,22 @@
+import os
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from functools import partial
+
+def test_index_page():
+    root = os.path.dirname(os.path.dirname(__file__))
+    handler = partial(SimpleHTTPRequestHandler, directory=root)
+    server = ThreadingHTTPServer(('localhost', 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        with urllib.request.urlopen(f'http://localhost:{port}/index.html') as resp:
+            text = resp.read().decode()
+            assert resp.status == 200
+            assert '(o_O)' in text
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- add a workflow to run pytest
- test that `/index.html` loads successfully and shows `(o_O)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a74efee70832f8ea6c716cad7a432